### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-#Android Color Thief
+# Android Color Thief
 A port to Android of Simon Oualid's "Java Color Thief".
 
 ![Example](https://raw.githubusercontent.com/HenriqueRocha/android-colorthief/master/sample/android-colorthief.png)
 
-##Credits and license
+## Credits and license
 
-###Author
+### Author
 Henrique Rocha (henrique.rocha@androidpit.de)
 
-###Thanks
+### Thanks
 * Simon Oualid (simon@oualid.net) - for the Java Color Thief version available at https://github.com/soualid/java-colorthief
 * Lokesh Dhakar - for the original Color Thief javascript version, available at http://lokeshdhakar.com/projects/color-thief/
 
-###License
+### License
 Licensed under the [Creative Commons Attribution 2.5 License](http://creativecommons.org/licenses/by/2.5/)
 
 * Free for use in both personal and commercial projects.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
